### PR TITLE
Render markdown links in track descriptions

### DIFF
--- a/components/blocks/event-schedule/event.tsx
+++ b/components/blocks/event-schedule/event.tsx
@@ -1,3 +1,4 @@
+import Markdown from 'markdown-to-jsx'
 import dayjs from 'dayjs'
 import classNames from 'classnames'
 import { Modal } from '../../modal'
@@ -98,9 +99,11 @@ function EventModalContent({ event }) {
           (tag && <Tag key={i}>{tag}</Tag>)
         ))}
       </div>
-      <p className="mg-copy-small mt-4">
-        {event.description}
-      </p>
+      {event.description && (
+        <p className="markdown mg-copy-small mt-4">
+          <Markdown>{event.description}</Markdown>
+        </p>
+      )}
       {event.timeslots?.length >= 1 && <TimeslotTable timeslots={event.timeslots} />}
     </>
   )

--- a/content/tracks/Closing-Dinner.md
+++ b/content/tracks/Closing-Dinner.md
@@ -7,7 +7,7 @@ priority: 9
 venueName: Plein Publiek BXL
 venueAddress: 'Mont des Arts, 1000 Bruxelles, Belgium'
 difficulty: All Welcome
-description: 'https://lu.ma/ipfsthing-closing19'
+description: '[https://lu.ma/ipfsthing-closing19](https://lu.ma/ipfsthing-closing19)'
 ---
 
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "date-fns": "^2.23.0",
     "dayjs": "^1.11.7",
     "fathom-client": "^3.5.0",
+    "markdown-to-jsx": "^7.2.0",
     "next": "^12.3.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6911,6 +6911,11 @@ markdown-table@^3.0.0:
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-3.0.3.tgz#e6331d30e493127e031dd385488b5bd326e4a6bd"
   integrity sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==
 
+markdown-to-jsx@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.2.0.tgz#e7b46b65955f6a04d48a753acd55874a14bdda4b"
+  integrity sha512-3l4/Bigjm4bEqjCR6Xr+d4DtM1X6vvtGsMGSjJYyep8RjjIvcWtrXBS8Wbfe1/P+atKNMccpsraESIaWVplzVg==
+
 material-colors@^1.2.1:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"


### PR DESCRIPTION
Fixes issue #169 by rendering the description in a markdown component ([markdown-to-jsx](https://github.com/probablyup/markdown-to-jsx)). 

Note that there is a TinaMarkdown component in our project but this specifically renders markdown coming from the Tina rich text field object, not a simple string.