### PR TITLE
Add the ability to link directly to a timeslot in a track modal

### DIFF
--- a/components/blocks/event-schedule/event.tsx
+++ b/components/blocks/event-schedule/event.tsx
@@ -2,6 +2,7 @@ import Markdown from 'markdown-to-jsx'
 import dayjs from 'dayjs'
 import classNames from 'classnames'
 import { Modal } from '../../modal'
+import Link from 'next/link.js'
 
 function Card({ children, color }) {
   let borderColor = 'bg-gray'
@@ -34,48 +35,50 @@ export function EventCard({ event, urlHash }) {
   const isWorkInProgress = event.tags?.some((el) => el.toLowerCase() === "wip")
   return (
     <Modal content={<EventModalContent event={event}/>} title={event.name} link={event.website} hash={event.hash} urlHash={urlHash}>
-      <div className={classNames('w-full', 'h-full', 'overflow-hidden', { 'opacity-70': isWorkInProgress })}>
-        <Card color={event.color}>
-          <div className="flex-1">
-            <div className="flex gap-2">
-              <h5 className="flex-1 text-black mg-headline-small">
-                {event.name}
-              </h5>
-              {event.isLive &&
-                <div className="w-12 mt-0.5 flex-none">
-                  <img width="48" height="18" src="/live-streaming.svg" />
+      <Link href={`/${event.hash}`} scroll={false}>
+        <div className={classNames('w-full', 'h-full', 'overflow-hidden', { 'opacity-70': isWorkInProgress })}>
+          <Card color={event.color}>
+            <div className="flex-1">
+              <div className="flex gap-2">
+                <h5 className="flex-1 text-black mg-headline-small">
+                  {event.name}
+                </h5>
+                {event.isLive &&
+                  <div className="w-12 mt-0.5 flex-none">
+                    <img width="48" height="18" src="/live-streaming.svg" />
+                  </div>
+                }
+              </div>
+              <div className="mg-copy-small mt-2">
+                {event.times !== "To be confirmed" &&
+                  <div>{event.times}</div>
+                }
+                {event.venueName && event.venueName != "Private" &&
+                  <div>{event.venueName}</div>
+                }
+                <div>
+                  👤 {event.attendees && `${event.attendees} -`} {event.difficulty}
+                </div>
+                <div className="mt-3">
+                  {event.org}
+                </div>
+              </div>
+            </div>
+            <div className="flex-1 flex items-end">
+              <div className="event-tags">
+                {event.tags?.map((tag, i) => (
+                  (tag && <Tag key={i}>{tag}</Tag>)
+                ))}
+              </div>
+              {event.logomark &&
+                <div className="logomark inline-block">
+                  <img height="48" className="w-auto h-12 object-contain" src={event.logomark} />
                 </div>
               }
             </div>
-            <div className="mg-copy-small mt-2">
-              {event.times !== "To be confirmed" &&
-                <div>{event.times}</div>
-              }
-              {event.venueName && event.venueName != "Private" &&
-                <div>{event.venueName}</div>
-              }
-              <div>
-                👤 {event.attendees && `${event.attendees} -`} {event.difficulty}
-              </div>
-              <div className="mt-3">
-                {event.org}
-              </div>
-            </div>
-          </div>
-          <div className="flex-1 flex items-end">
-            <div className="event-tags">
-              {event.tags?.map((tag, i) => (
-                (tag && <Tag key={i}>{tag}</Tag>)
-              ))}
-            </div>
-            {event.logomark &&
-              <div className="logomark inline-block">
-                <img height="48" className="w-auto h-12 object-contain" src={event.logomark} />
-              </div>
-            }
-          </div>
-        </Card>
-      </div>
+          </Card>
+        </div>
+      </Link>
     </Modal>
   )
 }
@@ -100,9 +103,9 @@ function EventModalContent({ event }) {
         ))}
       </div>
       {event.description && (
-        <p className="markdown mg-copy-small mt-4">
+        <div className="markdown mg-copy-small mt-4">
           <Markdown>{event.description}</Markdown>
-        </p>
+        </div>
       )}
       {event.timeslots?.length >= 1 && <TimeslotTable timeslots={event.timeslots} />}
     </>
@@ -166,9 +169,9 @@ function TimeslotTable({ timeslots }) {
               <td className="px-6 py-4">
                 <span className="font-bold">{timeslot.title}</span>
                 {timeslot.description && (
-                  <p className="markdown">
+                  <div className="markdown">
                     <Markdown>{timeslot.description}</Markdown>
-                  </p>
+                  </div>
                 )}
               </td>
             </tr>

--- a/components/blocks/event-schedule/event.tsx
+++ b/components/blocks/event-schedule/event.tsx
@@ -34,7 +34,7 @@ function Card({ children, color }) {
 export function EventCard({ event, urlHash }) {
   const isWorkInProgress = event.tags?.some((el) => el.toLowerCase() === "wip")
   return (
-    <Modal content={<EventModalContent event={event}/>} title={event.name} link={event.website} hash={event.hash} urlHash={urlHash}>
+    <Modal content={<EventModalContent event={event} urlHash={urlHash}/>} title={event.name} link={event.website} hash={event.hash} urlHash={urlHash}>
       <Link href={`/${event.hash}`} scroll={false}>
         <div className={classNames('w-full', 'h-full', 'overflow-hidden', { 'opacity-70': isWorkInProgress })}>
           <Card color={event.color}>
@@ -83,7 +83,7 @@ export function EventCard({ event, urlHash }) {
   )
 }
 
-function EventModalContent({ event }) {
+function EventModalContent({ event, urlHash }) {
   return (
     <>
       <ul className="list-disc mg-copy-small ml-4">
@@ -107,7 +107,7 @@ function EventModalContent({ event }) {
           <Markdown>{event.description}</Markdown>
         </div>
       )}
-      {event.timeslots?.length >= 1 && <TimeslotTable timeslots={event.timeslots} />}
+      {event.timeslots?.length >= 1 && <TimeslotTable timeslots={event.timeslots} hash={event.hash} urlHash={urlHash} />}
     </>
   )
 }
@@ -148,7 +148,7 @@ function AddEventModalContent({config}) {
   )
 }
 
-function TimeslotTable({ timeslots }) {
+function TimeslotTable({ timeslots, hash, urlHash }) {
   const sortedTimeslots = timeslots.sort((a, b) => a.time.localeCompare(b.time))
   return (
     <div>
@@ -161,21 +161,26 @@ function TimeslotTable({ timeslots }) {
             <th scope="col" className="px-6 py-3">INFO</th>
           </tr>
         </thead>
-        <tbody>
-          {sortedTimeslots?.map((timeslot, i) => (
-            <tr key={i} className="bg-white mg-copy-small border-b border-gray-light">
-              <th scope="row" className="px-6 py-4 align-top whitespace-nowrap text-left">{timeslot.time}</th>
-              <td className="px-6 py-4 align-top">{timeslot.speakers}</td>
-              <td className="px-6 py-4">
-                <span className="font-bold">{timeslot.title}</span>
-                {timeslot.description && (
-                  <div className="markdown">
-                    <Markdown>{timeslot.description}</Markdown>
-                  </div>
-                )}
-              </td>
-            </tr>
-          ))}
+        <tbody className="mg-copy-small">
+          {sortedTimeslots?.map((timeslot, i) => {
+            const timeslotId = `${hash}-timeslot${i+1}`
+            const currentTimeslot = urlHash?.replace('/', '-timeslot')
+            const isCurrent = timeslotId === currentTimeslot
+            return (
+              <tr id={timeslotId} key={i} className={`relative border-b border-gray-light ${isCurrent ? 'bg-gray-light' : 'bg-white' }`} >
+                <th scope="row" className="px-6 py-4 align-top whitespace-nowrap text-left">{timeslot.time}</th>
+                <td className="px-6 py-4 align-top">{timeslot.speakers}</td>
+                <td className="px-6 py-4">
+                  <a className="font-bold underline" href={`/${hash}/${i+1}`}>{timeslot.title}</a>
+                  {timeslot.description && (
+                    <div className="markdown">
+                      <Markdown>{timeslot.description}</Markdown>
+                    </div>
+                  )}
+                </td>
+              </tr>
+            )
+          })}
         </tbody>
       </table>
     </div>

--- a/components/blocks/event-schedule/schedule-table.tsx
+++ b/components/blocks/event-schedule/schedule-table.tsx
@@ -38,7 +38,6 @@ export function ScheduleTable({ events, config }) {
     setUrlHash(window.location.hash)
     if (!hashChangeEventRegistered) {
       window.addEventListener('hashchange', (hashChangeEvent) => {
-        console.log('hashChangeEvent', hashChangeEvent)
         setUrlHash( (new URL(hashChangeEvent.newURL)).hash)
       });
       setHashChangeEventRegistered(true)

--- a/components/blocks/event-schedule/schedule-table.tsx
+++ b/components/blocks/event-schedule/schedule-table.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import dayjs from 'dayjs'
 import { EventCard } from './event'
-import Link from 'next/link.js'
 
 
 function genDates(start, numDays) {
@@ -24,9 +23,9 @@ function EventCardWrapper({event, index, urlHash}) {
   }
   return (
     <div className={`col-start-${(event.startDay + 1)} col-end-${(event.startDay + event.days + 1)} shrink-0 h-full auto-rows-fr`}>
-        <Link href={`/${event.hash}`} scroll={false} >
-          <EventCard event={event} key={index} urlHash={urlHash} />
-        </Link>
+      <div className={`col-start-${(event.startDay + 1)} col-end-${(event.startDay + event.days + 1)} shrink-0 h-full auto-rows-fr`}>
+        <EventCard event={event} key={index} urlHash={urlHash} />
+      </div>
     </div>
   )
 }
@@ -39,6 +38,7 @@ export function ScheduleTable({ events, config }) {
     setUrlHash(window.location.hash)
     if (!hashChangeEventRegistered) {
       window.addEventListener('hashchange', (hashChangeEvent) => {
+        console.log('hashChangeEvent', hashChangeEvent)
         setUrlHash( (new URL(hashChangeEvent.newURL)).hash)
       });
       setHashChangeEventRegistered(true)

--- a/components/modal.tsx
+++ b/components/modal.tsx
@@ -30,11 +30,28 @@ function setLocationHash(hash) {
 }
 
 export function Modal({ children, content, title, link, hash, urlHash }) {
+  const modalHash = urlHash.includes('/') ? urlHash.split('/').at(0) : urlHash
   const [openModal, setOpenModal] = useState(urlHash === hash);
+  
+  const scrollToTimeslot = () => {
+    const timeslotIndex = urlHash.includes('/') && urlHash.split('/').at(1)
+    if (modalHash && timeslotIndex) {
+      const timeSlotId = `${modalHash}-timeslot${Number(timeslotIndex) + 1}`
+      const element = document.getElementById(timeSlotId)
+      element && element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }
 
   const open = () => {
-    setLocationHash(hash)
-    setOpenModal(true)
+    if (!openModal) {
+      setLocationHash(hash)
+      setOpenModal(true)
+    }
+
+    // The modal needs to be open before we can scroll to the timeslot
+    setTimeout(() => {
+      scrollToTimeslot()
+    }, 100);
   }
   const close = () => {
     setLocationHash('#')
@@ -42,7 +59,7 @@ export function Modal({ children, content, title, link, hash, urlHash }) {
   }
 
   useEffect(() => {
-    if (urlHash === hash) {
+    if (modalHash === hash) {
       open()
     } else {
       setOpenModal(false)


### PR DESCRIPTION
1. Open a track modal and then click a timeslot title.
2. The timeslot will be highlighted, copy the url
3. Open a new window and paste the url. The modal will open and scroll down to the timeslot with it highlighted.

This also fixes an error caused by ref.